### PR TITLE
Fix URLs of mirror and dark site

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -7,10 +7,10 @@ function redirect(page, setting) {
         window.location.href = "https://namu.wiki/w/" + page;
     }
     else if (setting === "namu-mirror-wiki") {
-        window.location.href = "http://namu.mirror.wiki/wiki/" + page;
+        window.location.href = "https://namu.mirror.wiki/w/" + page;
     }
     else if (setting === "dark-namu-wiki") {
-        window.location.href = "https://dark.namu.wiki/w/" + page;
+        window.location.href = "https://namu.mirror.wiki/dark/" + page;
     }
     else {
         window.location.href = "https://namu.wiki/w/" + page;

--- a/src/google_result.js
+++ b/src/google_result.js
@@ -20,11 +20,11 @@ function redirect(a, setting, regex) {
                 break;
 
             case "namu-mirror-wiki":
-                a.href = a.href.replace(regex, "https://namu.mirror.wiki/wiki");
+                a.href = a.href.replace(regex, "https://namu.mirror.wiki/w");
                 break;
 
             case "dark-namu-wiki":
-                a.href = a.href.replace(regex, "https://namu.mirror.wiki/wiki");
+                a.href = a.href.replace(regex, "https://namu.mirror.wiki/dark");
                 break;
 
             default:

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -16,28 +16,28 @@
         <select name="" id="rigvedawiki-net">
           <option value="namu-wiki">namu.wiki로 이동</option>
           <option value="namu-mirror-wiki">namu.mirror.wiki로 이동</option>
-          <option value="dark-namu-wiki">dark.namu.wiki로 이동</option>
+          <option value="dark-namu-wiki">namu.mirror.wiki/dark로 이동</option>
           <option value="none">아무 것도 하지 않음</option>
         </select>
         <p class="description">mirror.enha.kr를 접속하였을 때</p>
         <select name="" id="mirror-enha-kr">
           <option value="namu-wiki">namu.wiki로 이동</option>
           <option value="namu-mirror-wiki">namu.mirror.wiki로 이동</option>
-          <option value="dark-namu-wiki">dark.namu.wiki로 이동</option>
+          <option value="dark-namu-wiki">namu.mirror.wiki/dark로 이동</option>
           <option value="none">아무 것도 하지 않음</option>
         </select>
         <p class="description">mir.pe를 접속하였을 때</p>
         <select name="" id="mir-pe">
           <option value="namu-wiki">namu.wiki로 이동</option>
           <option value="namu-mirror-wiki">namu.mirror.wiki로 이동</option>
-          <option value="dark-namu-wiki">dark.namu.wiki로 이동</option>
+          <option value="dark-namu-wiki">namu.mirror.wiki/dark로 이동</option>
           <option value="none">아무 것도 하지 않음</option>
         </select>
         <p class="description">namu.moe를 접속하였을 때</p>
         <select name="" id="namu-moe">
           <option value="namu-wiki">namu.wiki로 이동</option>
           <option value="namu-mirror-wiki">namu.mirror.wiki로 이동</option>
-          <option value="dark-namu-wiki">dark.namu.wiki로 이동</option>
+          <option value="dark-namu-wiki">namu.mirror.wiki/dark로 이동</option>
           <option value="none">아무 것도 하지 않음</option>
         </select>
         <br /><br />


### PR DESCRIPTION
https://dark.namu.wiki isn't available now, so I replaced it with https://namu.mirror.wiki/dark. Also http://namu.mirror.wiki/wiki is now replaced with https://namu.mirror.wiki/w.
