### PR TITLE
Fix a bug that redirects to same page continuously

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -12,9 +12,6 @@ function redirect(page, setting) {
     else if (setting === "dark-namu-wiki") {
         window.location.href = "https://namu.mirror.wiki/dark/" + page;
     }
-    else {
-        window.location.href = "https://namu.wiki/w/" + page;
-    }
 }
 
 chrome.storage.sync.get(["rigvedawikiNet", "mirrorEnhaKr", "mirPe", "namuMirrorWiki", "namuMoe", "namuWiki"], function (items) {
@@ -49,8 +46,15 @@ chrome.storage.sync.get(["rigvedawikiNet", "mirrorEnhaKr", "mirPe", "namuMirrorW
         page = href.substr(getPosition(href, "/", 4) + 1);
         redirect(page, mirPe);
     }
-    else if (href.indexOf("namu.mirror.wiki") !== -1) {
-        if (namuMirrorWiki === "none") {
+    else if (href.indexOf("namu.mirror.wiki/w/") !== -1) {
+        if (namuMirrorWiki === "none" || namuWiki === "namu-mirror-wiki") {
+            return;
+        }
+        page = href.substr(getPosition(href, "/", 4) + 1);
+        redirect(page, namuMirrorWiki);
+    }
+    else if (href.indexOf("namu.mirror.wiki/dark/") !== -1) {
+        if (namuMirrorWiki === "none" || namuWiki === "dark-namu-wiki") {
             return;
         }
         page = href.substr(getPosition(href, "/", 4) + 1);
@@ -64,7 +68,7 @@ chrome.storage.sync.get(["rigvedawikiNet", "mirrorEnhaKr", "mirPe", "namuMirrorW
         redirect(page, namuMoe);
     }
     else if (href.indexOf("namu.wiki") !== -1) {
-        if (namuWiki === "none") {
+        if (namuWiki === "none" || namuWiki === "namu-wiki") {
             return;
         }
         page = href.substr(getPosition(href, "/", 4) + 1);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -49,7 +49,6 @@
         </select>
         <p class="description">namu.wiki를 접속하였을 때</p>
         <select name="" id="namu-wiki">
-          <option value="namu-wiki">namu.wiki로 이동</option>
           <option value="namu-mirror-wiki">namu.mirror.wiki로 이동</option>
           <option value="dark-namu-wiki">namu.mirror.wiki/dark로 이동</option>
           <option value="none">아무 것도 하지 않음</option>

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -29,7 +29,7 @@ function restore_options () {
         mirPe: "namu-wiki",
         namuMirrorWiki: "namu-mirror-wiki",
         namuMoe: "namu-wiki",
-        namuWiki: "namu-wiki"
+        namuWiki: "none"
     }, function (items) {
         document.getElementById("rigvedawiki-net").value = items.rigvedawikiNet;
         document.getElementById("mirror-enha-kr").value = items.mirrorEnhaKr;


### PR DESCRIPTION
When we set `namuWiki` to `"namu-wiki"` and open a namu.wiki page, it redirects to itself continuously. This pull request fix the bug.
